### PR TITLE
fix: Picker: cannot read property 'value' of undefined

### DIFF
--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -35,7 +35,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
     testID
   } = props;
   const context = useContext(PickerContext);
-  const [wheelPickerValue, setWheelPickerValue] = useState<PickerSingleValue>(context.value ?? items?.[0].value);
+  const [wheelPickerValue, setWheelPickerValue] = useState<PickerSingleValue>(context.value ?? items?.[0]?.value);
   // TODO: Might not need this memoized style, instead we can move it to a stylesheet
   const wrapperContainerStyle = useMemo(() => {
     // const shouldFlex = Constants.isWeb ? 1 : useDialog ? 1 : 1;


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
fix: Picker: cannot read property 'value' of undefined

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
Add an extra ? for optional chaining solved this issue

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
fixes: #2936
